### PR TITLE
address deprecation warnings

### DIFF
--- a/owned.sol
+++ b/owned.sol
@@ -28,21 +28,19 @@ contract Owned
     address public owner;
 
     /// Constructor: initializes owner
-    function Owned() {
+    function Owned() public {
         owner = msg.sender;
     }
 
     /// Ensure that only the owner can call a function
     modifier onlyOwner {
-        if (msg.sender != owner)
-            throw;
+        require(msg.sender == owner);
         _;
     }
 
     /// Ensure address is set to something relatively sane
     modifier onlyValidRecipient(address _recipient) {
-        if (_recipient == address(0))
-            throw;
+        require(_recipient != address(0));
         _;
     }
 

--- a/proven.sol
+++ b/proven.sol
@@ -34,7 +34,7 @@ contract Proven is Owned {
     event DepositionPublished(bytes32 _deposition, address _deponent, bytes _ipfs_hash);
 
     /// Constructor must be passed a backend
-    function Proven(address _registry) {
+    function Proven(address _registry) public {
         registry = ProvenRegistry(_registry);
     }
 

--- a/proven_db.sol
+++ b/proven_db.sol
@@ -41,19 +41,17 @@ contract ProvenDb is Owned
     }
 
     modifier onlyProven() {
-        if (msg.sender != registry.proven())
-            throw;
+        require(msg.sender == registry.proven());
         _;
     }
 
     modifier onlyNewReceipt(bytes32 _id) {
-        if (depositions[_id].deponent != 0)
-            throw;
+        require(depositions[_id].deponent == 0);
         _;
     }
 
     /// Constructor
-    function ProvenDb(address _registry) {
+    function ProvenDb(address _registry) public {
         registry = ProvenRegistry(_registry);
     }
 

--- a/proven_relay.sol
+++ b/proven_relay.sol
@@ -30,7 +30,7 @@ contract ProvenRelay is Owned {
     event DepositionPublished(address _deponent, bytes _ipfs_hash);
 
     /// Constructor must be passed a backend
-    function ProvenRelay() {
+    function ProvenRelay() public {
     }
 
     /// Publish a deposition

--- a/server.sol
+++ b/server.sol
@@ -4,7 +4,7 @@ contract Server{
     bool public alive = true;
     function homicide(){
         alive = false;
-        suicide(msg.sender);
+        selfdestruct(msg.sender);
     }
 }
 

--- a/verifier_db.sol
+++ b/verifier_db.sol
@@ -74,7 +74,7 @@ contract VerifierDb is Owned {
 
     function verify(bytes32 _deposition, address _verifier, uint _bondAmount) public onlyVerifier {
 
-        Verification storage v = verifications[_deposition];
+        Verification memory v = verifications[_deposition];
 
         v.state = State.Verified;
         v.verifier = _verifier;

--- a/verifier_db.sol
+++ b/verifier_db.sol
@@ -48,7 +48,7 @@ contract VerifierDb is Owned {
 
     function getDetails(bytes32 _deposition) public constant onlyVerifier returns(State state, uint bounty, address verifier, uint verifiedInBlock, address challenger, uint challengedInBlock, uint bondAmount, address contestor) {
 
-        Verification storage v = verifications[_deposition];
+        Verification memory v = verifications[_deposition];
 
         state = v.state;
         bounty = v.bounty;
@@ -62,10 +62,12 @@ contract VerifierDb is Owned {
 
     function initialize(bytes32 _deposition, uint _bounty) public onlyVerifier {
 
-        Verification storage v = verifications[_deposition];
+        Verification memory v = verifications[_deposition];
 
         v.state = State.Initialized;
         v.bounty = _bounty;
+
+        verifications[_deposition] = v;
 
         Stored(_deposition, _bounty);
     }
@@ -79,45 +81,55 @@ contract VerifierDb is Owned {
         v.verifiedInBlock = block.number;
         v.bondAmount = _bondAmount;
 
+        verifications[_deposition] = v;
+
         Verified(_deposition, _verifier);
     }
 
     function prove(bytes32 _deposition) public onlyVerifier {
 
-        Verification storage v = verifications[_deposition];
+        Verification memory v = verifications[_deposition];
 
         v.state = State.Proven;
+
+        verifications[_deposition] = v;
 
         Proven(_deposition);
     }
 
     function challenge(bytes32 _deposition, address _challenger, uint _bondAmount) public onlyVerifier {
 
-        Verification storage v = verifications[_deposition];
+        Verification memory v = verifications[_deposition];
 
         v.state = State.Challenged;
         v.challenger = _challenger;
         v.challengedInBlock = block.number;
         v.bondAmount = _bondAmount;
 
+        verifications[_deposition] = v;
+
         Challenged(_deposition, _challenger);
     }
 
     function disprove(bytes32 _deposition) public onlyVerifier {
 
-        Verification storage v = verifications[_deposition];
+        Verification memory v = verifications[_deposition];
 
         v.state = State.Disproven;
+
+        verifications[_deposition] = v;
 
         Disproven(_deposition);
     }
 
     function contest(bytes32 _deposition, address _contestor) public onlyVerifier {
 
-        Verification storage v = verifications[_deposition];
+        Verification memory v = verifications[_deposition];
 
         v.state = State.Contested;
         v.contestor = _contestor;
+
+        verifications[_deposition] = v;
 
         Contested(_deposition, _contestor);
     }

--- a/verifier_db.sol
+++ b/verifier_db.sol
@@ -38,18 +38,17 @@ contract VerifierDb is Owned {
     event Contested(bytes32 deposition, address contestor);
 
     modifier onlyVerifier() {
-        if (msg.sender != registry.verifier())
-            throw;
+        require (msg.sender == registry.verifier());
         _;
     }
 
-    function VerifierDb(address _registry) {
+    function VerifierDb(address _registry) public {
         registry = VerifierRegistry(_registry);
     }
 
     function getDetails(bytes32 _deposition) public constant onlyVerifier returns(State state, uint bounty, address verifier, uint verifiedInBlock, address challenger, uint challengedInBlock, uint bondAmount, address contestor) {
 
-        Verification v = verifications[_deposition];
+        Verification storage v = verifications[_deposition];
 
         state = v.state;
         bounty = v.bounty;
@@ -63,7 +62,7 @@ contract VerifierDb is Owned {
 
     function initialize(bytes32 _deposition, uint _bounty) public onlyVerifier {
 
-        Verification v = verifications[_deposition];
+        Verification storage v = verifications[_deposition];
 
         v.state = State.Initialized;
         v.bounty = _bounty;
@@ -73,7 +72,7 @@ contract VerifierDb is Owned {
 
     function verify(bytes32 _deposition, address _verifier, uint _bondAmount) public onlyVerifier {
 
-        Verification v = verifications[_deposition];
+        Verification storage v = verifications[_deposition];
 
         v.state = State.Verified;
         v.verifier = _verifier;
@@ -85,7 +84,7 @@ contract VerifierDb is Owned {
 
     function prove(bytes32 _deposition) public onlyVerifier {
 
-        Verification v = verifications[_deposition];
+        Verification storage v = verifications[_deposition];
 
         v.state = State.Proven;
 
@@ -94,7 +93,7 @@ contract VerifierDb is Owned {
 
     function challenge(bytes32 _deposition, address _challenger, uint _bondAmount) public onlyVerifier {
 
-        Verification v = verifications[_deposition];
+        Verification storage v = verifications[_deposition];
 
         v.state = State.Challenged;
         v.challenger = _challenger;
@@ -106,7 +105,7 @@ contract VerifierDb is Owned {
 
     function disprove(bytes32 _deposition) public onlyVerifier {
 
-        Verification v = verifications[_deposition];
+        Verification storage v = verifications[_deposition];
 
         v.state = State.Disproven;
 
@@ -115,7 +114,7 @@ contract VerifierDb is Owned {
 
     function contest(bytes32 _deposition, address _contestor) public onlyVerifier {
 
-        Verification v = verifications[_deposition];
+        Verification storage v = verifications[_deposition];
 
         v.state = State.Contested;
         v.contestor = _contestor;


### PR DESCRIPTION
* Change `throw` to `require()` or `assert()`
* Store variables in memory, not storage (maybe these can be `var`s?)