### PR TITLE
Enable code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 **/*.swp
 build/merged
+coverage/
+coverage.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,14 @@ node_js:
   - "7"
 install:
   - npm install -g truffle solium
+  - npm install -g ganache-cli
   - npm install
 script:
   - solium --dir contracts/
   - truffle compile
   - truffle test
+before_script:
+  - testrpc > /dev/null &
+  - sleep 5
+after_script:
+  - npm run coverage && cat coverage/lcov.info | coveralls

--- a/contracts/BondHolder.sol
+++ b/contracts/BondHolder.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.4.18;
 
-import "zeppelin-solidity/contracts/ownership/Ownable.sol";
+import "./Ownable.sol";
 import "./BondHolderRegistry.sol";
 
 

--- a/contracts/BondHolderRegistry.sol
+++ b/contracts/BondHolderRegistry.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.4.18;
 
-import "zeppelin-solidity/contracts/ownership/Ownable.sol";
+import "./Ownable.sol";
 
 
 contract BondHolderRegistry is Ownable {

--- a/contracts/Ownable.sol
+++ b/contracts/Ownable.sol
@@ -1,0 +1,43 @@
+pragma solidity ^0.4.18;
+
+// This file is from zeppelin-solidity 1.6.0
+
+/**
+ * @title Ownable
+ * @dev The Ownable contract has an owner address, and provides basic authorization control
+ * functions, this simplifies the implementation of "user permissions".
+ */
+contract Ownable {
+  address public owner;
+
+
+  event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+
+  /**
+   * @dev The Ownable constructor sets the original `owner` of the contract to the sender
+   * account.
+   */
+  function Ownable() public {
+    owner = msg.sender;
+  }
+
+  /**
+   * @dev Throws if called by any account other than the owner.
+   */
+  modifier onlyOwner() {
+    require(msg.sender == owner);
+    _;
+  }
+
+  /**
+   * @dev Allows the current owner to transfer control of the contract to a newOwner.
+   * @param newOwner The address to transfer ownership to.
+   */
+  function transferOwnership(address newOwner) public onlyOwner {
+    require(newOwner != address(0));
+    OwnershipTransferred(owner, newOwner);
+    owner = newOwner;
+  }
+
+}

--- a/contracts/Proven.sol
+++ b/contracts/Proven.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.4.18;
 
-import "zeppelin-solidity/contracts/ownership/Ownable.sol";
+import "./Ownable.sol";
 import "./ProvenRegistry.sol";
 import "./ProvenDB.sol";
 

--- a/contracts/ProvenDB.sol
+++ b/contracts/ProvenDB.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.4.18;
 
-import "zeppelin-solidity/contracts/ownership/Ownable.sol";
+import "./Ownable.sol";
 import "./ProvenRegistry.sol";
 
 

--- a/contracts/ProvenRegistry.sol
+++ b/contracts/ProvenRegistry.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.4.18;
 
-import "zeppelin-solidity/contracts/ownership/Ownable.sol";
+import "./Ownable.sol";
 
 
 /// Registry

--- a/contracts/Verifier.sol
+++ b/contracts/Verifier.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.4.18;
 
-import "zeppelin-solidity/contracts/ownership/Ownable.sol";
+import "./Ownable.sol";
 import "./VerifierRegistry.sol";
 import "./VerifierDB.sol";
 import "./Proven.sol";

--- a/contracts/VerifierDB.sol
+++ b/contracts/VerifierDB.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.4.18;
 
-import "zeppelin-solidity/contracts/ownership/Ownable.sol";
+import "./Ownable.sol";
 import "./VerifierRegistry.sol";
 
 

--- a/contracts/VerifierRegistry.sol
+++ b/contracts/VerifierRegistry.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.4.18;
 
-import "zeppelin-solidity/contracts/ownership/Ownable.sol";
+import "./Ownable.sol";
 
 
 /// VerifierRegistry

--- a/package.json
+++ b/package.json
@@ -4,23 +4,25 @@
   "private": true,
   "description": "Proven Suite",
   "devDependencies": {
+    "coveralls": "^3.0.0",
     "mkdirp": "^0.5.1",
     "sol-merger": "^0.1.2",
-    "solc": "^0.4.9"
+    "solc": "^0.4.19",
+    "solidity-coverage": "^0.4.9"
   },
   "license": "AGPL-3.0",
   "scripts": {
     "build": "./node_modules/.bin/truffle compile",
     "build-contracts": "mkdir -p ./build/merged ; ./node_modules/.bin/sol-merger './contracts/*.sol' ./build/merged",
+    "coverage": "./node_modules/.bin/solidity-coverage",
     "deploy-ropsten": "./node_modules/.bin/truffle migrate --network ropsten",
     "deploy-ganache": "./node_modules/.bin/truffle migrate --network ganache",
     "lint": "./node_modules/.bin/solium --dir contracts/",
     "test": "./node_modules/.bin/truffle test"
   },
   "dependencies": {
-    "solium": "^1.0.9",
-    "truffle": "^4.0.1",
-    "web3": "^0.18.0-beta",
-    "zeppelin-solidity": "^1.4.0"
+    "solium": "^1.1.3",
+    "truffle": "^4.0.5",
+    "web3": "^1.0.0-beta.29"
   }
 }


### PR DESCRIPTION
* Turn on code coverage
* Use open-zeppelin's Ownable by inclusion instead of by reference, for security purposes *and* because otherwise code coverage barfs
* Enable coveralls